### PR TITLE
Make compatible with latest version of the Android mode

### DIFF
--- a/examples/Select/Select.pde
+++ b/examples/Select/Select.pde
@@ -1,3 +1,9 @@
+// This sketch requires the READ_EXTERNAL_STORAGE permission to be selected
+// through the Sketch Permissions list in the PDE, and then to use the requestPermission()
+// function in the code, since READ_EXTERNAL_STORAGE is a dangerous permission that must
+// be requested during run-time in Android 23 and newer:
+// https://developer.android.com/guide/topics/permissions/requesting.html#normal-dangerous 
+
 import select.files.*;
 
 SelectLibrary files;
@@ -6,10 +12,18 @@ void setup() {
   size(320, 240);
   
   files = new SelectLibrary(this);
-  
-  files.selectInput("Select a file to process:", "fileSelected");
+  requestPermission("android.permission.READ_EXTERNAL_STORAGE", "handleRequest");
+    
   // files.selectFolder("Select a folder to process:", "fileSelected");
   // files.selectOutput("Save the file please:", "fileSelected");
+}
+
+void handleRequest(boolean granted) {
+  if (granted) {
+    files.selectInput("Select a file to process:", "fileSelected");
+  } else {
+    println("Does not have permission to read external storage.");
+  }
 }
 
 void fileSelected(File selection) {

--- a/src/select/files/SelectDialog.java
+++ b/src/select/files/SelectDialog.java
@@ -83,9 +83,9 @@ public class SelectDialog extends Dialog {
 
   private ListView listView = null;
   
-  public SelectDialog(PApplet context, Intent intent) {
-    super(context);
-    this.parent = context;
+  public SelectDialog(PApplet parent, Intent intent) {
+    super(parent.getContext());
+    this.parent = parent;
     this.intent = intent;
   }
   

--- a/src/select/files/SelectLibrary.java
+++ b/src/select/files/SelectLibrary.java
@@ -29,6 +29,7 @@ package select.files;
 import java.io.File;
 
 import processing.core.PApplet;
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
 import android.os.Environment;
@@ -115,11 +116,15 @@ public class SelectLibrary {
     i.putExtra(SelectDialog.EX_CALLBACK, callbackMethod);
     i.putExtra(SelectDialog.EX_TITLE, prompt);
     
-    parent.runOnUiThread(new Runnable() {
-        public void run() {
-          Dialog dlg = new SelectDialog(parent, i);
-          dlg.show();//startActivityForResult(i, RESULT_SELECT);
-        }
-    });
+    
+    Activity activity = parent.getActivity();
+    if (activity != null) {
+      activity.runOnUiThread(new Runnable() {
+          public void run() {
+            Dialog dlg = new SelectDialog(parent, i);
+            dlg.show();//startActivityForResult(i, RESULT_SELECT);
+          }
+      });
+    }
   }
 }


### PR DESCRIPTION
The Android mode in the 4.x betas changed its architecture quite significantly, one important difference with previous versions of the mode is that PApplet is not longer a subclass of Activity. This modification breaks the android-select-file library, and this PR addresses the issue by accessing the underlying activity and context through new API in PApplet. Also, the READ_EXTERNAL_STORAGE is considered a dangerous permission, which needs to be requested in run-time in Android 23 and newer, so the example has been updated accordingly to use the new requestPermission() function available in the mode.

Built and tested the library against version [4.0-beta8](https://github.com/processing/processing-android/releases/tag/android-261) of the Android mode.